### PR TITLE
pearl: Remove Power-off Alarm

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -275,10 +275,6 @@ PRODUCT_COPY_FILES += \
         frameworks/native/data/etc/com.android.nfc_extras.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/com.android.nfc_extras.xml \
         frameworks/native/data/etc/com.nxp.mifare.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/com.nxp.mifare.xml
 
-# Power-off Alarm
-PRODUCT_PACKAGES += \
-    PowerOffAlarm
-
 # Modules
 PRODUCT_PACKAGES += \
     init.insmod.sh \


### PR DESCRIPTION
```
out/soong/.intermediates/vendor/lineage/build/soong/generated_kernel_includes/gen/usr/include/asm/sigcontext.h:77:2:error: unknown type name '__uint128_t'
   77 |         __uint128_t vregs[32];
      |         ^

```
didnt want to waste time fix this