### PR TITLE
pearl: Fix permissions for Goodix/FPC fingerprint sensors

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -834,8 +834,6 @@ vendor/etc/init/vendor.xiaomi.hardware.mfidoca@1.0-miteeservice.rc
 vendor/lib64/libmfido_mitee.so
 
 # Fingerprint
-vendor/bin/hw/mfp-daemon
-vendor/etc/init/init.mfp-daemon.rc
 vendor/framework/com.fingerprints.extension.jar
 vendor/lib64/hw/fingerprint.fpc.so
 vendor/lib64/com.fingerprints.extension@3.0.so

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -591,6 +591,7 @@ vendor/lib64/libvpu5.so
 vendor/lib64/vendor.mediatek.hardware.camera.atms@1.0.so
 vendor/lib64/vendor.mediatek.hardware.camera.bgservice@1.0.so
 vendor/lib64/vendor.mediatek.hardware.camera.bgservice@1.1.so
+vendor/lib64/vendor.mediatek.hardware.camera.ccap@1.0.so
 vendor/lib64/vendor.mediatek.hardware.camera.device@3.6.so
 vendor/lib64/vendor.mediatek.hardware.camera.frhandler@1.0.so
 vendor/lib64/vendor.mediatek.hardware.camera.isphal@1.0.so
@@ -712,9 +713,12 @@ vendor/lib64/mt6895/pearls5k4h7_mipi_raw_tuning.so;SYMLINK=vendor/lib64/pearls5k
 
 # Charger (Mi Turbo Charge)
 vendor/bin/batterysecret
+vendor/bin/smartcharging
 vendor/bin/hw/vendor.xiaomi.hardware.micharge@1.0-service
+vendor/etc/init/smartcharging_init.rc
 vendor/etc/init/vendor.xiaomi.hardware.micharge@1.0-service.rc
 vendor/etc/vintf/manifest/vendor.xiaomi.hardware.micharge@1.0.xml
+vendor/lib64/libsmartcharging.so
 vendor/lib64/hw/vendor.xiaomi.hardware.micharge@1.0-impl.so
 vendor/lib64/vendor.xiaomi.hardware.micharge@1.0.so
 
@@ -738,6 +742,7 @@ vendor/etc/init/chipinfo_init.rc
 
 # Display Configs
 vendor/etc/cust_color.xml
+vendor/etc/dsi_l16s_36_02_0a_dsc_vdo_mi.xml
 
 # Display
 vendor/bin/hw/mt6895/android.hardware.graphics.allocator@4.0-service-mediatek.mt6895;SYMLINK=vendor/bin/hw/android.hardware.graphics.allocator@4.0-service-mediatek
@@ -818,6 +823,11 @@ vendor/etc/vintf/manifest/manifest_android.hardware.drm@1.4-service.widevine.xml
 vendor/lib64/mediadrm/libwvdrmengine.so
 vendor/lib64/libwvhidl.so
 
+# Fpsgo
+vendor/bin/fpsgo
+vendor/etc/init/fpsgo.rc
+vendor/etc/init/init.fpsgo.rc
+
 # Fido
 vendor/bin/fidoca_mitee
 vendor/etc/init/vendor.xiaomi.hardware.mfidoca@1.0-miteeservice.rc
@@ -832,6 +842,7 @@ vendor/lib64/com.fingerprints.extension@3.0.so
 
 # FM Radio
 vendor/etc/init/init.fmradio_drv.rc
+vendor/firmware/fm_cust.cfg
 vendor/firmware/mt6627_fm_v1_coeff.bin
 vendor/firmware/mt6627_fm_v1_patch.bin
 vendor/firmware/mt6630_fm_v1_coeff.bin
@@ -858,6 +869,7 @@ vendor/lib64/hw/gatekeeper.mitee.so
 vendor/bin/hw/android.hardware.gnss-service.mediatek
 vendor/bin/mnld
 vendor/bin/mtk_agpsd
+vendor/etc/MNL_Config.xml
 vendor/etc/init/android.hardware.gnss-service.mediatek.rc
 vendor/etc/init/init.gps_drv.rc
 vendor/etc/init/init.gps_pwr.rc
@@ -865,6 +877,7 @@ vendor/etc/init/init.gps_scp.rc
 vendor/etc/init/mtk_agpsd_p.rc
 vendor/etc/vintf/manifest/gnss-default.xml:vendor/etc/vintf/manifest/gnss-mtk.xml
 vendor/etc/vintf/manifest/gnss@2.1-service.xml
+vendor/etc/mpe.conf
 vendor/etc/slp_conf
 vendor/lib64/hw/android.hardware.gnss-impl-mediatek.so
 vendor/lib64/hw/android.hardware.gnss@2.1-impl-mediatek.so
@@ -912,7 +925,6 @@ vendor/etc/vintf/manifest/android.hardware.security.sharedsecret-service.mitee.x
 vendor/lib64/hw/local_time.default.so
 
 # Media
-vendor/etc/seccomp_policy/mediacodec.policy
 vendor/lib64/libMtkOmxCore.so
 vendor/lib64/libadpcmdec_mtk.so
 vendor/lib64/libalacdec_mtk.so
@@ -961,16 +973,6 @@ vendor/lib64/vendor.mediatek.hardware.mms@1.3.so
 vendor/lib64/vendor.mediatek.hardware.mms@1.4.so
 vendor/lib64/vendor.mediatek.hardware.mms@1.5.so
 vendor/lib64/vendor.mediatek.hardware.mms@1.6.so
-
-# Media configs
-vendor/etc/media_codecs.xml
-vendor/etc/media_codecs_c2.xml
-vendor/etc/media_codecs_dolby_audio.xml
-vendor/etc/media_codecs_google_audio.xml
-vendor/etc/media_codecs_mediatek_audio.xml
-vendor/etc/media_codecs_performance.xml
-vendor/etc/media_codecs_system_default.xml
-vendor/etc/media_profiles_V1_0.xml
 
 # Mlipay
 vendor/bin/mlipayd_mitee@1.1
@@ -1191,16 +1193,6 @@ vendor/lib64/vendor.mediatek.hardware.videotelephony@1.0.so
 # RenderScript
 vendor/lib64/hw/android.hardware.renderscript@1.0-impl.so
 
-# Rsc config
-vendor/etc/rsc/CN/ro.prop
-vendor/etc/rsc/CN/rw.prop
-vendor/etc/rsc/GL/ro.prop
-vendor/etc/rsc/GL/rw.prop
-vendor/etc/rsc/IN/ro.prop
-vendor/etc/rsc/IN/rw.prop
-vendor/etc/rsc/default/ro.prop
-vendor/etc/rsc/default/rw.prop
-
 # Secure element
 vendor/bin/hw/android.hardware.secure_element@1.2-service-mediatek
 vendor/bin/hw/vendor.xiaomi.hardware.secure_element@1.2-service
@@ -1212,6 +1204,7 @@ vendor/lib64/ls_nq_client-v1.so
 vendor/lib64/se_nq_extn_client-v1.so
 
 # Sensors
+vendor/etc/elliptic_sensor.xml
 vendor/firmware/remoteproc_scp
 vendor/lib64/hw/sensors.elliptic@2.0.so
 vendor/lib64/hw/sensors.mediatek.V2.0.so;SYMLINK=vendor/lib64/hw/sensors.mt6895.so
@@ -1226,12 +1219,6 @@ vendor/lib64/libultrasound.so
 vendor/etc/sensors/hals.conf
 vendor/etc/sensors/lightSensorCali.json
 vendor/etc/sensors/lightSensorConfig.json
-
-# Seccomp policy
-vendor/etc/seccomp_policy/android.hardware.media.c2@1.2-extended-seccomp-policy
-vendor/etc/seccomp_policy/android.hardware.media.c2@1.2-mediatek-seccomp-policy
-vendor/etc/seccomp_policy/mediaextractor.policy
-vendor/etc/seccomp_policy/mediaswcodec.policy
 
 # Soter
 product/app/SoterService/SoterService.apk
@@ -1256,6 +1243,10 @@ vendor/lib64/vendor.mediatek.hardware.netdagent@1.0.so
 
 # Thermal (Xiaomi)
 vendor/bin/mi_thermald
+vendor/bin/thermal_core
+vendor/bin/thermal_intf
+vendor/etc/init/init.thermal_core.rc
+vendor/etc/thermalbreakboostconfig.xml
 vendor/lib64/hw/thermal_hal.so
 
 # Thermal configs
@@ -1355,70 +1346,34 @@ vendor/firmware/soc7_0_ram_wmmcu_1b_t_1_hdr.bin
 vendor/firmware/soc7_0_ram_wmmcu_1c_1_hdr.bin
 
 # Miscellaneous
-vendor/bin/mt6895/dumpfaultd.mt6895;SYMLINK=vendor/bin/dumpfaultd
-vendor/bin/mt6895/jpegtool;SYMLINK=vendor/bin/jpegtool
-vendor/bin/fpsgo
-vendor/bin/ois_cal
-vendor/bin/smartcharging
-vendor/bin/thermal_core
-vendor/bin/thermal_intf
-vendor/etc/init/fpsgo.rc
-vendor/etc/init/init.fpsgo.rc
-vendor/etc/init/init.thermal_core.rc
-vendor/etc/init/smartcharging_init.rc
 vendor/etc/1-SN1X0_SPC.txt
-vendor/etc/MNL_Config.xml
 vendor/etc/audio_em.xml
 vendor/etc/audio_policy.conf
 vendor/etc/breakwhiteapplist.xml
-vendor/etc/capture_headset_left.sh
-vendor/etc/capture_headset_right.sh
 vendor/etc/default_pd_calibration.bin
 vendor/etc/device_sar_config.xml
-vendor/etc/dsi_l16s_36_02_0a_dsc_vdo_mi.xml
-vendor/etc/elliptic_sensor.xml
 vendor/etc/excluded-input-devices.xml
 vendor/etc/fstb.cfg
-vendor/etc/init.panel_info.sh
 vendor/etc/meow.cfg
-vendor/etc/miperf_actvity_cfg.xml
-vendor/etc/miperf_app_cfg.xml
-vendor/etc/miperf_contable.xml
-vendor/etc/miperflock_activity_cfg.xml
 vendor/etc/mono.cnt
-vendor/etc/mpe.conf
 vendor/etc/mtk_omx_core.cfg
-vendor/etc/mtk_platform_codecs_config.xml
 vendor/etc/mtk_vext_info
 vendor/etc/nhw
-vendor/etc/partition_permission.sh
-vendor/etc/playback_headset_left.sh
-vendor/etc/playback_headset_right.sh
 vendor/etc/power_app_cfg.xml
 vendor/etc/powercontable.xml
 vendor/etc/powerscntbl.xml
-vendor/etc/public.libraries.txt
 vendor/etc/screen_light.xml
 vendor/etc/sensor_diag.cfg
 vendor/etc/smsdbvisitor.xml
 vendor/etc/task_profiles.json
-vendor/etc/thermalbreakboostconfig.xml
-vendor/etc/throttle.sh
 vendor/etc/usb_audio_accessory_only_policy_configuration.xml
 vendor/etc/wfd_source_capability.csv
 vendor/etc/xgf.cfg
-vendor/firmware/fm_cust.cfg
 vendor/firmware/mali_csffw.bin
 vendor/firmware/mali_csffw_reload.bin
 vendor/firmware/mono.cnt
-vendor/lib64/libapmonitor_vendor.so
 vendor/lib64/libappgamepq.so
 vendor/lib64/libnir_neon_driver_ndk.mtk.vndk.so;FIX_SONAME
-vendor/lib64/libsmartcharging.so
-vendor/lib64/vendor.mediatek.hardware.apmonitor@2.0.so
-vendor/lib64/vendor.mediatek.hardware.atci@1.0.so
-vendor/lib64/vendor.mediatek.hardware.camera.ccap@1.0.so
 vendor/lib64/vendor.mediatek.hardware.clientapi@1.0.so
-vendor/lib64/vendor.mediatek.hardware.lbs@1.0.so
 vendor/lib64/vendor.mediatek.hardware.mdmonitor@1.0.so
 vendor/lib64/vendor.xiaomi.sensor.citsensorservice@1.1.so

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -132,7 +132,6 @@
 # Displayfeature
 /data/vendor/display(/.*)? u:object_r:vendor_display_data_file:s0
 /(vendor|system\/vendor)/bin/displayfeature u:object_r:vendor_displayfeature_exec:s0
-/(vendor|system\/vendor)/bin/hw/vendor\.xiaomi\.hardware\.displayfeature@1\.0-service u:object_r:vendor_hal_displayfeature_xiaomi_default_exec:s0
 
 # Ir
 /dev/ir_spi u:object_r:vendor_ir_spi_device:s0
@@ -149,6 +148,9 @@
 /data/vendor/goodix(/.*)? u:object_r:fingerprint_vendor_data_file:s0
 /mnt/vendor/persist/fpc(/.*)? u:object_r:fingerprint_vendor_data_file:s0
 /mnt/vendor/persist/goodix(/.*)? u:object_r:fingerprint_vendor_data_file:s0
+/sys/devices/platform/fingerprint(/.*)? u:object_r:vendor_sysfs_fp:s0
+/dev/goodix_fp u:object_r:fingerprint_device:s0
+/dev/xiaomi-fp u:object_r:fingerprint_device:s0
 
 # Graphics
 /dev/mi_display/disp_feature u:object_r:vendor_displayfeature_device:s0
@@ -186,12 +188,14 @@
 /vendor/bin/soterd u:object_r:hal_soterservice_default_exec:s0
 
 # Tee
-/dev/0:0:0:49476 u:object_r:teei_rpmb_device:s0
 /(vendor|system\/vendor)/bin/tee-supplicant u:object_r:tee_exec:s0
 /(vendor|system\/vendor)/bin/miteelog u:object_r:tee_exec:s0
+/mnt/vendor/persist/data(/.*)? u:object_r:mitee_sfs_file:s0
+/dev/0:0:0:49476 u:object_r:teei_rpmb_device:s0
 /dev/tee0 u:object_r:mitee_client_device:s0
 /dev/teepriv0 u:object_r:mitee_client_device:s0
 /dev/ufs-bsg0 u:object_r:mitee_client_device:s0
+/data/vendor/mitee(/.*)? u:object_r:mitee_data_file:s0
 
 # Tidaservice
 /vendor/bin/tidad_mitee@1\.2 u:object_r:hal_tidaservice_default_exec:s0

--- a/sepolicy/vendor/hwservice_contexts
+++ b/sepolicy/vendor/hwservice_contexts
@@ -12,7 +12,6 @@ com.fingerprints.extension::IFingerprintSensorTest                              
 com.fingerprints.extension::IFingerprintCalibration                                  u:object_r:vendor_hal_fingerprint_hwservice_xiaomi:s0
 com.fingerprints.extension::IFingerprintOptical                                      u:object_r:vendor_hal_fingerprint_hwservice_xiaomi:s0
 com.fingerprints.extension::IFingerprintSenseTouch                                   u:object_r:vendor_hal_fingerprint_hwservice_xiaomi:s0
-vendor.xiaomi.hardware.dtool::IDtool                                             u:object_r:vendor_hal_fingerprint_hwservice_xiaomi:s0
 
 # Fido
 vendor.xiaomi.hardware.mfidoca::IFidoService                                  u:object_r:hal_mfidoca_hwservice:s0

--- a/sepolicy/vendor/property_contexts
+++ b/sepolicy/vendor/property_contexts
@@ -30,13 +30,13 @@ persist.vendor.sys.rkp.status u:object_r:vendor_mlipay_prop:s0
 vendor.sys.feature_state u:object_r:vendor_mlipay_prop:s0
 vendor.sys.rpmb_state u:object_r:vendor_mlipay_prop:s0
 
+# Mitee
+vendor.teefs_state u:object_r:vendor_mtk_mitee_prop:s0
+ro.boot.tee_type u:object_r:vendor_mtk_mitee_prop:s0
+ro.vendor.mtk_mitee_support u:object_r:vendor_mtk_mitee_prop:s0
+
 # Sensors
 ro.vendor.sensors.xiaomi. u:object_r:vendor_sensors_prop:s0
 
 # Thermal
 vendor.sys.thermal.data.path u:object_r:vendor_thermal_prop:s0
-
-# Mitee
-vendor.teefs_state u:object_r:vendor_mtk_mitee_prop:s0
-ro.boot.tee_type u:object_r:vendor_mtk_mitee_prop:s0
-ro.vendor.mtk_mitee_support u:object_r:vendor_mtk_mitee_prop:s0


### PR DESCRIPTION
* We don't copy mfp-daemon since it's not really needed for the fingerprint sensor to function. However, the init rc for this
  daemon actually contains a lot of important permission changes required for the Fingerprint HALs to work properly. Partially import these changes into a new rc file with a little clean-up and the mfp-daemon service definition removed.