### PR TITLE
pearl: Bump Fingerprint and Fixup bluetooth\wifi\gps

### DIFF
--- a/extract-files.py
+++ b/extract-files.py
@@ -44,9 +44,6 @@ blob_fixups: blob_fixups_user_type = {
 	'vendor/lib64/hw/android.hardware.gnss-impl-mediatek.so'): blob_fixup()
     .replace_needed('android.hardware.gnss-V1-ndk_platform.so','android.hardware.gnss-V1-ndk.so'),
 
-	'vendor/bin/hw/vendor.mediatek.hardware.mtkpower@1.0-service': blob_fixup()
-    .replace_needed('android.hardware.power-V2-ndk_platform.so','android.hardware.power-V2-ndk.so'),
-
     ('vendor/lib64/mt6895/libcam.hal3a.so',
      'vendor/lib64/mt6895/libcam.hal3a.ctrl.so',
      'vendor/lib64/mt6895/libmtkcam_request_requlator.so'): blob_fixup()
@@ -96,8 +93,7 @@ blob_fixups: blob_fixups_user_type = {
         .add_needed('libprocessgroup_shim.so')
         .replace_needed('libavservices_minijail_vendor.so', 'libavservices_minijail.so'),
 
-    ('vendor/bin/hw/vendor.mediatek.hardware.pq@2.2-service',
-     'vendor/lib64/mt6895/libmtkcam_stdutils.so',
+    ('vendor/lib64/mt6895/libmtkcam_stdutils.so',
      'vendor/lib64/hw/mt6895/android.hardware.camera.provider@2.6-impl-mediatek.so',
      'vendor/lib64/hw/mt6895/vendor.mediatek.hardware.pq@2.15-impl.so'): blob_fixup()
         .replace_needed('libutils.so', 'libutils-v32.so'),

--- a/lineage_pearl.mk
+++ b/lineage_pearl.mk
@@ -34,8 +34,8 @@ WITH_GMS := false
 PRODUCT_DEX_PREOPT_GENERATE_DM_FILES := true
 
 PRODUCT_BUILD_PROP_OVERRIDES += \
-    BuildFingerprint="xiaomi/pearl/pearl:15/AP3A.240905.015.A2/OS2.0.205.0.VLHCNXM:user/release-keys"
+    BuildFingerprint="xiaomi/pearl/pearl:15/AP3A.240905.015.A2/OS2.0.207.0.VLHCNXM:user/release-keys"
 
 # Set BUILD_FINGERPRINT variable to be picked up by both system and vendor build.prop
-BUILD_FINGERPRINT := Xiaomi/pearl/pearl:15/AP3A.240905.015.A2/OS2.0.205.0.VLHCNXM:user/release-keys
+BUILD_FINGERPRINT := Xiaomi/pearl/pearl:15/AP3A.240905.015.A2/OS2.0.207.0.VLHCNXM:user/release-keys
 

--- a/vendor.prop
+++ b/vendor.prop
@@ -2,8 +2,8 @@
 audio.deep_buffer.media=true
 audio.offload.video=true
 audio.offload.min.duration.secs=30
-aaudio.mmap_policy=2
-aaudio.mmap_exclusive_policy=2
+aaudio.mmap_policy=0
+aaudio.mmap_exclusive_policy=0
 ro.audio.monitorRotation=true
 ro.vendor.audio.gain.support=true
 ro.config.media_vol_default=10

--- a/vendor.prop
+++ b/vendor.prop
@@ -137,7 +137,7 @@ persist.vendor.fingerprint.type=side
 persist.vendor.fingerprint.sensor_location=1080|960|200|local:4627039422300187648
 
 # GNSS
-ro.vendor.gps.chrdev=gps_drv_dl_v050
+ro.vendor.gps.chrdev=gps_drv
 ro.vendor.mtk_log_hide_gps=1
 
 # Graphics
@@ -282,7 +282,7 @@ ro.apk_verity.mode=2
 # Wi-Fi
 ro.vendor.wifi.sap.concurrent.iface=ap1
 ro.vendor.wifi.sap.interface=ap0
-ro.vendor.wlan.chrdev=wmt_chrdev_wifi_connac2
+ro.vendor.wlan.chrdev=wmt_chrdev_wifi
 ro.vendor.wlan.gen=gen4m_6895
 
 # Zygote


### PR DESCRIPTION
Due to the changes of mt6895-common kernel, We should set ro.vendor.wlan.chrdev=wmt_chrdev_wifi and ro.vendor.gps.chrdev=gps_drv temporarily for basic use,Maybe have some problem in future