### PR TITLE
pearl: Fixup fixblob for vendor.mediatek.hardware.pq@2.15-impl

### DIFF
--- a/extract-files.py
+++ b/extract-files.py
@@ -94,15 +94,17 @@ blob_fixups: blob_fixups_user_type = {
         .replace_needed('libavservices_minijail_vendor.so', 'libavservices_minijail.so'),
 
     ('vendor/lib64/mt6895/libmtkcam_stdutils.so',
-     'vendor/lib64/hw/mt6895/android.hardware.camera.provider@2.6-impl-mediatek.so',
-     'vendor/lib64/hw/mt6895/vendor.mediatek.hardware.pq@2.15-impl.so'): blob_fixup()
+     'vendor/lib64/hw/mt6895/android.hardware.camera.provider@2.6-impl-mediatek.so'): blob_fixup()
         .replace_needed('libutils.so', 'libutils-v32.so'),
 
     'vendor/bin/hw/mtkfusionrild': blob_fixup()
         .add_needed('libutils-v32.so'),
 
-    ('vendor/lib64/hw/mt6895/vendor.mediatek.hardware.pq@2.15-impl.so',
-     'vendor/lib64/mt6895/libaalservice.so',
+    'vendor/lib64/hw/mt6895/vendor.mediatek.hardware.pq@2.15-impl.so': blob_fixup()
+        .replace_needed('libutils.so', 'libutils-v32.so')
+        .replace_needed('libsensorndkbridge.so', 'android.hardware.sensors@1.0-convert-shared.so'),
+
+    ('vendor/lib64/mt6895/libaalservice.so',
      'vendor/bin/mnld'): blob_fixup()
         .replace_needed('libsensorndkbridge.so', 'android.hardware.sensors@1.0-convert-shared.so'),
 
@@ -130,6 +132,7 @@ blob_fixups: blob_fixups_user_type = {
 
     'vendor/etc/public.libraries.txt': blob_fixup()
         .add_line_if_missing('libmpbase.so'),
+
 }  # fmt: skip
 
 module = ExtractUtilsModule(

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -483,8 +483,6 @@ vendor/lib64/mt6895/libmtkcam_ulog.so;SYMLINK=vendor/lib64/libmtkcam_ulog.so
 vendor/lib64/mt6895/libmtkcm_ipc_dummy.so;SYMLINK=vendor/lib64/libmtkcm_ipc_dummy.so
 vendor/lib64/mt6895/libpda_usdriver.so;SYMLINK=vendor/lib64/libpda_usdriver.so
 vendor/lib64/mt6895/libnir_neon_driver.so;SYMLINK=vendor/lib64/libnir_neon_driver.so
-vendor/lib64/mt6895/libpq_cust_base.so;SYMLINK=vendor/lib64/libpq_cust_base.so
-vendor/lib64/mt6895/libpq_prot.so;SYMLINK=vendor/lib64/libpq_prot.so
 vendor/lib64/mt6895/libstereoinfoaccessor_vsdof.so;SYMLINK=vendor/lib64/libstereoinfoaccessor_vsdof.so
 vendor/lib64/mt6895/libvainr_model.so;SYMLINK=vendor/lib64/libvainr_model.so
 vendor/lib64/lib3a.ae.pipe.so
@@ -763,6 +761,8 @@ vendor/lib64/hw/mt6895/vulkan.mali.so;SYMLINK=vendor/lib64/hw/vulkan.mali.so
 vendor/lib64/hw/hwcomposer.mtk_common.so
 vendor/lib64/mt6895/arm.graphics-V1-ndk_platform.so;SYMLINK=vendor/lib64/arm.graphics-V1-ndk_platform.so
 vendor/lib64/mt6895/libaalservice.so;SYMLINK=vendor/lib64/libaalservice.so
+vendor/lib64/mt6895/libpq_cust_base.so;SYMLINK=vendor/lib64/libpq_cust_base.so
+vendor/lib64/mt6895/libpq_prot.so;SYMLINK=vendor/lib64/libpq_prot.so
 vendor/lib64/mt6895/libpqparamparser.so;SYMLINK=vendor/lib64/libpqparamparser.so
 vendor/lib64/mt6895/libpqpconfig.so;SYMLINK=vendor/lib64/libpqpconfig.so
 vendor/lib64/libDefaultFpsActor.so


### PR DESCRIPTION
Fixup
09-09 13:43:23.998  1521  1521 F DEBUG   : Cmdline: /vendor/bin/hw/vendor.mediatek.hardware.pq@2.2-service
09-09 13:43:23.998  1521  1521 F DEBUG   : pid: 1518, tid: 1518, name: vendor.mediatek  >>> /vendor/bin/hw/vendor.mediatek.hardware.pq@2.2-service <<<
09-09 13:43:23.998  1521  1521 F DEBUG   : uid: 1000
09-09 13:43:23.998  1521  1521 F DEBUG   : tagged_addr_ctrl: 0000000000000001 (PR_TAGGED_ADDR_ENABLE)
09-09 13:43:23.998  1521  1521 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
09-09 13:43:23.998  1521  1521 F DEBUG   : Abort message: 'incStrongRequireStrong() called on 0xb40000710088f940 which isn't already owned'
